### PR TITLE
Updated RailsInstaller OSX video

### DIFF
--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -10,7 +10,7 @@ $('#lightbox').click(function() {
 $(function() {
   if(navigator.platform.indexOf('Mac') != -1) {
     $('#downloadlink').attr('href','https://github.com/downloads/railsinstaller/railsinstaller-nix/RailsInstaller-1.0.0-osx-10.7.app.tgz');
-    $('.vimeolink').attr('href','http://vimeo.com/43220631');
+    $('.vimeolink').attr('href','http://vimeo.com/43823464');
     $('.vimeoframe').attr('src','http://player.vimeo.com/video/43220631?byline=0&amp;portrait=0');
     $('#windows').hide();
     $('#osx').show();


### PR DESCRIPTION
Updated video can be viewed at https://vimeo.com/43823464. This includes installing as well as deploying to EY Cloud
