### PR TITLE
Make it harder to miss how to actually download the package

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -110,7 +110,7 @@
             <p>
               <i>RailsInstaller</i> has everything you need to hit the ground running.
               In one easy-to-use installer, you get all the common packages needed for a full Rails stack.
-              <a href="http://rubyforge.org/frs/download.php/75894/railsinstaller-2.1.0.exe" id='downloadlink'>
+              <a href="https://github.com/downloads/railsinstaller/railsinstaller-nix/RailsInstaller-1.0.3-osx-10.7.app.tgz" id='downloadlink'>
 		Download it now
 	      </a>
               and be writing (and running) Rails code in no time.


### PR DESCRIPTION
The big green button doesn't always read as a button. Instead it looks like a banner or header, which leads newbies to scroll down the page and look for the thing to click to actually download the kit. This leads to those various links to other sites (Ruby, Rails, Git...) and so people get lost, often thinking they've gotten Railsinstaller when actually they got something else.

Having participated in many installfests I can assure you this is a real usability issue. It was just reported again here: https://groups.google.com/d/msg/railsbridge-workshops/CNT54c8JZZs/Oy5PwqHBtGQJ

This commit attempts to solve this by (a) making "Download it now" a link and (b) making it more clear that the list of links is _not_ actually what you want to click on to download the kit.

I'm a little confused though, since I'm not sure how the Windows download link transforms into the Mac download link. There's some JS in javascripts/application.js but I don't get how (or if) it really works. If someone explains this to me I'd be happy to amend this patch. 
