### PR TITLE
Fix download link for Windows because html is fubar

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -111,7 +111,7 @@
             <p>
               <i>RailsInstaller</i> has everything you need to hit the ground running.
               In one easy-to-use installer, you get all the common packages needed for a full Rails stack.
-              <a href="http://railsinstaller.s3.amazonaws.com/RailsInstaller-1.0.4-osx-10.7.app.tgz" id='downloadlink'>
+              <a href="http://rubyforge.org/frs/download.php/75894/railsinstaller-2.1.0.exe" id='downloadlink'>
                 Download it now
               </a>
               and be writing (and running) Rails code in no time.


### PR DESCRIPTION
I mistakenly told @alexch to change the download link in the Mac section. Apparently the html is so bad that this broke whatever the Javascript is doing. This change just reverts that.
