### PR TITLE
Revert download links

### DIFF
--- a/app/views/welcome/index.html.haml
+++ b/app/views/welcome/index.html.haml
@@ -18,9 +18,7 @@
             %i RailsInstaller
             has everything you need to hit the ground running.
             In one easy-to-use installer, you get all the common packages needed for a full Rails stack.
-            %a#downloadlink{:href => ri_win_download}
-              Download it now
-            and be writing (and running) Rails code in no time.
+            Download it now and be writing (and running) Rails code in no time.
           %p
             Packages included are:
           %ul
@@ -58,9 +56,7 @@
             %i RailsInstaller
             has everything you need to hit the ground running.
             In one easy-to-use installer, you get all the common packages needed for a full Rails stack.
-            %a#downloadlink{:href => ri_win_download}
-              Download it now
-            and be writing (and running) Rails code in no time.
+            Download it now and be writing (and running) Rails code in no time.
           %p
             Packages included are:
           %ul


### PR DESCRIPTION
The "Download it now" in the paragraphs seems to be broken because of the poorly-written javascript. Cannot have multiple elements with the same ID. Pulled this change back out because the big green button should be pretty obvious what you need to press to get everything.
