### PR TITLE
Reflect the version of Rails being installed - v4.0

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -50,7 +50,7 @@ en:
       rails_tutorial: Ruby on Rails Tutorial
       rails_tutorial_preffix: Another great resource is the
       rails_tutorial_suffix: by Michael Hartl. While the tutorial is Mac-focused, it does provide great value and insight for Windows users as well. Additionally, there is about 15 hours of accompanying video to in case you're more visually-oriented.
-      rails_ver_new: 3.2
+      rails_ver_new: 4.0
       rails_ver_old: 3.0.7
       repositories_preffix: in the respective repositories (
       repositories_suffix: ).


### PR DESCRIPTION
The website indicates that Rails 3.2 will be installed, but Rails version 4.0 is being installed.

https://github.com/railsinstaller/railsinstaller-windows/issues/30
