### PR TITLE
update dependencies to work with Ruby 2.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,7 +37,7 @@ GEM
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
     erubis (2.7.0)
-    eventmachine (1.0.3)
+    eventmachine (1.0.7)
     execjs (2.2.2)
     ffi (1.9.6)
     gh_contributors (0.8.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,7 +139,7 @@ GEM
       hitimes
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    uber (0.0.11)
+    uber (0.0.13)
     uglifier (2.5.3)
       execjs (>= 0.3.0)
       json (>= 1.8.0)


### PR DESCRIPTION
This will fix `bundle install` for Ruby 2.2.

info in https://github.com/eventmachine/eventmachine/pull/503